### PR TITLE
Enable wrapping errors while prefixing the error message.

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -133,6 +133,33 @@ func TestWrapError(t *testing.T) {
 	}
 }
 
+func TestWrapPrefixError(t *testing.T) {
+
+	e := func() error {
+		return WrapPrefix("hi", "prefix", 1)
+	}()
+
+	fmt.Println(e.Error())
+	if e.Error() != "prefix: hi" {
+		t.Errorf("Constructor with a string failed")
+	}
+
+	if WrapPrefix(fmt.Errorf("yo"), "prefix", 0).Error() != "prefix: yo" {
+		t.Errorf("Constructor with an error failed")
+	}
+
+	prefixed := WrapPrefix(e, "prefix", 0)
+	original := e.(*Error)
+
+	if prefixed.Err != original.Err || &prefixed.stack != &original.stack || &prefixed.frames != &original.frames || prefixed.Error() != "prefix: prefix: hi" {
+		t.Errorf("Constructor with an Error failed")
+	}
+
+	if WrapPrefix(nil, "prefix", 0).Error() != "prefix: <nil>" {
+		t.Errorf("Constructor with nil failed")
+	}
+}
+
 func ExampleErrorf(x int) (int, error) {
 	if x%2 == 1 {
 		return 0, Errorf("can only halve even numbers, got %d", x)


### PR DESCRIPTION
Hello,

First of all, thanks for this very useful library.
Here is a small improvement that I would find useful : It adds a method to wrap errors while providing context (as a prefix to the error message).
The use case would be to add meaningful context (in english) to users that may not have access to the source-code (in my case a CLI tool)

Here is an example use case:
```go
func ReadFile() *errors.Error {
  return errors.Errorf("File does not exist")
}

func ConquerTheWorld() *errors.Error {
  err := ReadFile()
  if err != nil {
    return errors.WrapPrefix(err, "Unable to read file", 1)
  }
}

err := ConquerTheWorld()
err.Error() == "Unable to read file: File does not exist"
```

The wrapped error has the same properties than with `Wrap` (keeps the stack trace etc)
Let me know what you think.
Best,

