### PR TITLE
Make Error an interface rather than a concrete type

### DIFF
--- a/error.go
+++ b/error.go
@@ -57,8 +57,18 @@ var MaxStackDepth = 50
 
 // Error is an error with an attached stacktrace. It can be used
 // wherever the builtin error interface is expected.
-type Error struct {
-	Err    error
+type Error interface {
+	error
+	Underlying() error
+	Stack() []byte
+	ErrorStack() string
+	StackFrames() []StackFrame
+	TypeName() string
+}
+
+// wrappedError is an implementation of the Error interface.
+type wrappedError struct {
+	err    error
 	stack  []uintptr
 	frames []StackFrame
 	prefix string
@@ -68,7 +78,7 @@ type Error struct {
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The stacktrace will point to the line of code that
 // called New.
-func New(e interface{}) *Error {
+func New(e interface{}) Error {
 	var err error
 
 	switch e := e.(type) {
@@ -80,8 +90,8 @@ func New(e interface{}) *Error {
 
 	stack := make([]uintptr, MaxStackDepth)
 	length := runtime.Callers(2, stack[:])
-	return &Error{
-		Err:   err,
+	return &wrappedError{
+		err:   err,
 		stack: stack[:length],
 	}
 }
@@ -90,11 +100,11 @@ func New(e interface{}) *Error {
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The skip parameter indicates how far up the stack
 // to start the stacktrace. 0 is from the current call, 1 from its caller, etc.
-func Wrap(e interface{}, skip int) *Error {
+func Wrap(e interface{}, skip int) Error {
 	var err error
 
 	switch e := e.(type) {
-	case *Error:
+	case *wrappedError:
 		return e
 	case error:
 		err = e
@@ -104,8 +114,8 @@ func Wrap(e interface{}, skip int) *Error {
 
 	stack := make([]uintptr, MaxStackDepth)
 	length := runtime.Callers(2+skip, stack[:])
-	return &Error{
-		Err:   err,
+	return &wrappedError{
+		err:   err,
 		stack: stack[:length],
 	}
 }
@@ -116,9 +126,9 @@ func Wrap(e interface{}, skip int) *Error {
 // error message when calling Error(). The skip parameter indicates how far
 // up the stack to start the stacktrace. 0 is from the current call,
 // 1 from its caller, etc.
-func WrapPrefix(e interface{}, prefix string, skip int) *Error {
+func WrapPrefix(e interface{}, prefix string, skip int) Error {
 
-	err := Wrap(e, skip)
+	err := Wrap(e, skip).(*wrappedError)
 
 	if err.prefix != "" {
 		err.prefix = fmt.Sprintf("%s: %s", prefix, err.prefix)
@@ -139,12 +149,12 @@ func Is(e error, original error) bool {
 		return true
 	}
 
-	if e, ok := e.(*Error); ok {
-		return Is(e.Err, original)
+	if e, ok := e.(*wrappedError); ok {
+		return Is(e.err, original)
 	}
 
-	if original, ok := original.(*Error); ok {
-		return Is(e, original.Err)
+	if original, ok := original.(*wrappedError); ok {
+		return Is(e, original.err)
 	}
 
 	return false
@@ -153,14 +163,19 @@ func Is(e error, original error) bool {
 // Errorf creates a new error with the given message. You can use it
 // as a drop-in replacement for fmt.Errorf() to provide descriptive
 // errors in return values.
-func Errorf(format string, a ...interface{}) *Error {
+func Errorf(format string, a ...interface{}) Error {
 	return Wrap(fmt.Errorf(format, a...), 1)
 }
 
-// Error returns the underlying error's message.
-func (err *Error) Error() string {
+// Underlying returns the underlying error.
+func (err *wrappedError) Underlying() error {
+	return err.err
+}
 
-	msg := err.Err.Error()
+// Error returns the underlying error's message.
+func (err wrappedError) Error() string {
+
+	msg := err.err.Error()
 	if err.prefix != "" {
 		msg = fmt.Sprintf("%s: %s", err.prefix, msg)
 	}
@@ -170,7 +185,7 @@ func (err *Error) Error() string {
 
 // Stack returns the callstack formatted the same way that go does
 // in runtime/debug.Stack()
-func (err *Error) Stack() []byte {
+func (err wrappedError) Stack() []byte {
 	buf := bytes.Buffer{}
 
 	for _, frame := range err.StackFrames() {
@@ -182,13 +197,13 @@ func (err *Error) Stack() []byte {
 
 // ErrorStack returns a string that contains both the
 // error message and the callstack.
-func (err *Error) ErrorStack() string {
+func (err wrappedError) ErrorStack() string {
 	return err.TypeName() + " " + err.Error() + "\n" + string(err.Stack())
 }
 
 // StackFrames returns an array of frames containing information about the
 // stack.
-func (err *Error) StackFrames() []StackFrame {
+func (err wrappedError) StackFrames() []StackFrame {
 	if err.frames == nil {
 		err.frames = make([]StackFrame, len(err.stack))
 
@@ -201,9 +216,9 @@ func (err *Error) StackFrames() []StackFrame {
 }
 
 // TypeName returns the type this error. e.g. *errors.stringError.
-func (err *Error) TypeName() string {
-	if _, ok := err.Err.(uncaughtPanic); ok {
+func (err wrappedError) TypeName() string {
+	if _, ok := err.err.(uncaughtPanic); ok {
 		return "panic"
 	}
-	return reflect.TypeOf(err.Err).String()
+	return reflect.TypeOf(err.err).String()
 }

--- a/error_test.go
+++ b/error_test.go
@@ -148,10 +148,10 @@ func TestWrapPrefixError(t *testing.T) {
 		t.Errorf("Constructor with an error failed")
 	}
 
-	prefixed := WrapPrefix(e, "prefix", 0)
-	original := e.(*Error)
+	prefixed := WrapPrefix(e, "prefix", 0).(*wrappedError)
+	original := e.(*wrappedError)
 
-	if prefixed.Err != original.Err || &prefixed.stack != &original.stack || &prefixed.frames != &original.frames || prefixed.Error() != "prefix: prefix: hi" {
+	if prefixed.err != original.err || &prefixed.stack != &original.stack || &prefixed.frames != &original.frames || prefixed.Error() != "prefix: prefix: hi" {
 		t.Errorf("Constructor with an Error failed")
 	}
 
@@ -207,18 +207,18 @@ func ExampleError_Error(err error) {
 }
 
 func ExampleError_ErrorStack(err error) {
-	fmt.Println(err.(*Error).ErrorStack())
+	fmt.Println(err.(Error).ErrorStack())
 }
 
-func ExampleError_Stack(err *Error) {
+func ExampleError_Stack(err Error) {
 	fmt.Println(err.Stack())
 }
 
-func ExampleError_TypeName(err *Error) {
+func ExampleError_TypeName(err Error) {
 	fmt.Println(err.TypeName(), err.Error())
 }
 
-func ExampleError_StackFrames(err *Error) {
+func ExampleError_StackFrames(err Error) {
 	for _, frame := range err.StackFrames() {
 		fmt.Println(frame.File, frame.LineNumber, frame.Package, frame.Name)
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -133,6 +133,28 @@ func TestWrapError(t *testing.T) {
 	}
 }
 
+// https://github.com/go-errors/errors/issues/3
+func TestNilError(t *testing.T) {
+
+	e := func() Error {
+		return nil
+	}()
+
+	var wrapped error
+	wrapped = func() *wrappedError {
+		return nil
+	}()
+
+	if e != nil {
+		t.Errorf("Error is not nil where it should be")
+	}
+
+	if wrapped == nil {
+		t.Errorf("*wrappedError is nil where it should not be")
+	}
+
+}
+
 func TestWrapPrefixError(t *testing.T) {
 
 	e := func() error {

--- a/parse_panic.go
+++ b/parse_panic.go
@@ -13,7 +13,7 @@ func (p uncaughtPanic) Error() string {
 
 // ParsePanic allows you to get an error object from the output of a go program
 // that panicked. This is particularly useful with https://github.com/mitchellh/panicwrap.
-func ParsePanic(text string) (*Error, error) {
+func ParsePanic(text string) (Error, error) {
 	lines := strings.Split(text, "\n")
 
 	state := "start"
@@ -68,7 +68,7 @@ func ParsePanic(text string) (*Error, error) {
 	}
 
 	if state == "done" || state == "parsing" {
-		return &Error{Err: uncaughtPanic{message}, frames: stack}, nil
+		return &wrappedError{err: uncaughtPanic{message}, frames: stack}, nil
 	}
 	return nil, Errorf("could not parse panic: %v", text)
 }


### PR DESCRIPTION
In Go, `error` is an interface, so making `errors.Error` a concrete type broke code such as the following:

```go
func goError() error {
    return nil
}

func myError() *errors.Error {
    return nil
}

func main() {

    err := goError()
    if err != nil {
        fmt.Println("goError not nil")
    }

    err = myError()
    if err != nil {
        fmt.Println("myError not nil")
    }

}
```

The code above prints "myError not nil", which can be troubling.
This is due to the way interfaces work in go (see https://news.ycombinator.com/item?id=5196241 for reference).

Introducing an `Error` interface is a breaking change, but resolves this kind of mistake by unexperienced go developpers.

In this commit, I have:
- renamed `Error` to `wrappedError` (not exported)
- added a new `Error` interface with the existing methods
- Added an `Underlying()` method to replace the `Err` property that cannot be accessed on the interface

Fixes #3