### PR TITLE
Wrap(nil) returns nil

### DIFF
--- a/error.go
+++ b/error.go
@@ -98,6 +98,8 @@ func Wrap(e interface{}, skip int) *Error {
 		return e
 	case error:
 		err = e
+	case nil:
+		return nil
 	default:
 		err = fmt.Errorf("%v", e)
 	}
@@ -117,6 +119,9 @@ func Wrap(e interface{}, skip int) *Error {
 // up the stack to start the stacktrace. 0 is from the current call,
 // 1 from its caller, etc.
 func WrapPrefix(e interface{}, prefix string, skip int) *Error {
+	if e == nil {
+		return nil
+	}
 
 	err := Wrap(e, skip)
 

--- a/error_test.go
+++ b/error_test.go
@@ -128,7 +128,7 @@ func TestWrapError(t *testing.T) {
 		t.Errorf("Constructor with an Error failed")
 	}
 
-	if Wrap(nil, 0).Error() != "<nil>" {
+	if Wrap(nil, 0) != nil {
 		t.Errorf("Constructor with nil failed")
 	}
 }
@@ -155,7 +155,7 @@ func TestWrapPrefixError(t *testing.T) {
 		t.Errorf("Constructor with an Error failed")
 	}
 
-	if WrapPrefix(nil, "prefix", 0).Error() != "prefix: <nil>" {
+	if WrapPrefix(nil, "prefix", 0) != nil {
 		t.Errorf("Constructor with nil failed")
 	}
 }


### PR DESCRIPTION
Hi

I have propose: I think it is cleaner to return nil if err is nil
What you think ?

```
{ 
  ...
  err := SomeFunc()
  return errors.Wrap(err, 0)
}


```
