### PR TITLE
Make tests succeed

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestStackFormatMatches(t *testing.T) {
+func TestStackFormat(t *testing.T) {
 
 	defer func() {
 		err := recover()
@@ -18,11 +18,24 @@ func TestStackFormatMatches(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		bs := [][]uintptr{Errorf("hi").stack, callers()}
+		e, expected := Errorf("hi"), callers()
+
+		bs := [][]uintptr{e.stack, expected}
 
 		if err := compareStacks(bs[0], bs[1]); err != nil {
 			t.Errorf("Stack didn't match")
 			t.Errorf(err.Error())
+		}
+
+		stack := string(e.Stack())
+
+		if !strings.Contains(stack, "a: b(5)") {
+			t.Errorf("Stack trace does not contain source line: 'a: b(5)'")
+			t.Errorf(stack)
+		}
+		if !strings.Contains(stack, "error_test.go:") {
+			t.Errorf("Stack trace does not contain file name: 'error_test.go:'")
+			t.Errorf(stack)
 		}
 	}()
 

--- a/error_test.go
+++ b/error_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"runtime/debug"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -18,16 +18,11 @@ func TestStackFormatMatches(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		bs := [][]byte{Errorf("hi").Stack(), debug.Stack()}
+		bs := [][]uintptr{Errorf("hi").stack, callers()}
 
-		// Ignore the first line (as it contains the PC of the .Stack() call)
-		bs[0] = bytes.SplitN(bs[0], []byte("\n"), 2)[1]
-		bs[1] = bytes.SplitN(bs[1], []byte("\n"), 2)[1]
-
-		if bytes.Compare(bs[0], bs[1]) != 0 {
+		if err := compareStacks(bs[0], bs[1]); err != nil {
 			t.Errorf("Stack didn't match")
-			t.Errorf("%s", bs[0])
-			t.Errorf("%s", bs[1])
+			t.Errorf(err.Error())
 		}
 	}()
 
@@ -42,15 +37,11 @@ func TestSkipWorks(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		bs := [][]byte{Wrap("hi", 2).Stack(), debug.Stack()}
+		bs := [][]uintptr{Wrap("hi", 2).stack, callersSkip(2)}
 
-		// should skip four lines of debug.Stack()
-		bs[1] = bytes.SplitN(bs[1], []byte("\n"), 5)[4]
-
-		if bytes.Compare(bs[0], bs[1]) != 0 {
+		if err := compareStacks(bs[0], bs[1]); err != nil {
 			t.Errorf("Stack didn't match")
-			t.Errorf("%s", bs[0])
-			t.Errorf("%s", bs[1])
+			t.Errorf(err.Error())
 		}
 	}()
 
@@ -71,16 +62,11 @@ func TestNew(t *testing.T) {
 		t.Errorf("Wrong message")
 	}
 
-	bs := [][]byte{New("foo").Stack(), debug.Stack()}
+	bs := [][]uintptr{New("foo").stack, callers()}
 
-	// Ignore the first line (as it contains the PC of the .Stack() call)
-	bs[0] = bytes.SplitN(bs[0], []byte("\n"), 2)[1]
-	bs[1] = bytes.SplitN(bs[1], []byte("\n"), 2)[1]
-
-	if bytes.Compare(bs[0], bs[1]) != 0 {
+	if err := compareStacks(bs[0], bs[1]); err != nil {
 		t.Errorf("Stack didn't match")
-		t.Errorf("%s", bs[0])
-		t.Errorf("%s", bs[1])
+		t.Errorf(err.Error())
 	}
 
 	if err.ErrorStack() != err.TypeName()+" "+err.Error()+"\n"+string(err.Stack()) {
@@ -244,4 +230,62 @@ func b(i int) {
 
 func c() {
 	panic('a')
+}
+
+// compareStacks will compare a stack created using the errors package (actual)
+// with a reference stack created with the callers function (expected). The
+// first entry is compared inexact since the actual and expected stacks cannot
+// be created at the exact same program counter position so the first entry
+// will always differ somewhat. Returns nil if the stacks are equal enough and
+// an error containing a detailed error message otherwise.
+func compareStacks(actual, expected []uintptr) error {
+	if len(actual) != len(expected) {
+		return stackCompareError("Stacks does not have equal length", actual, expected)
+	}
+	for i, pc := range actual {
+		if i == 0 {
+			firstEntryDiff := (int)(expected[i]) - (int)(pc)
+			if firstEntryDiff < -27 || firstEntryDiff > 27 {
+				return stackCompareError(fmt.Sprintf("First entry PC diff to large (%d)", firstEntryDiff), actual, expected)
+			}
+		} else if pc != expected[i] {
+			return stackCompareError(fmt.Sprintf("Stacks does not match entry %d (and maybe others)", i), actual, expected)
+		}
+	}
+	return nil
+}
+
+func stackCompareError(msg string, actual, expected []uintptr) error {
+	return fmt.Errorf("%s\nActual stack trace:\n%s\nExpected stack trace:\n%s", msg, readableStackTrace(actual), readableStackTrace(expected))
+}
+
+func callers() []uintptr {
+	return callersSkip(1)
+}
+
+func callersSkip(skip int) []uintptr {
+	callers := make([]uintptr, MaxStackDepth)
+	length := runtime.Callers(skip+2, callers[:])
+	return callers[:length]
+}
+
+func readableStackTrace(callers []uintptr) string {
+	var result bytes.Buffer
+	frames := callersToFrames(callers)
+	for _, frame := range frames {
+		result.WriteString(fmt.Sprintf("%s:%d (%#x)\n\t%s\n", frame.File, frame.Line, frame.PC, frame.Function))
+	}
+	return result.String()
+}
+
+func callersToFrames(callers []uintptr) []runtime.Frame {
+	frames := make([]runtime.Frame, 0, len(callers))
+	framesPtr := runtime.CallersFrames(callers)
+	for {
+		frame, more := framesPtr.Next()
+		frames = append(frames, frame)
+		if !more {
+			return frames
+		}
+	}
 }


### PR DESCRIPTION
So the tests have always failed on my machine because this package's stack trace format is not the same as `debug.Stack()`'s format. I don't know if the format used by `debug.Stack()` has changed in some go version and that's why the tests are failing. I also don't know if having the same format as `debug.Stack()` is a design goal or even desirable.

I know that I prefer this package's stack trace format over `debug.Stack()` since it puts more emphasis on the file and line number which is what I use the most when dealing with stack traces.

```
// go-errors stack trace
/Users/john.doe/go/src/github.com/go-errors/errors/error_test.go:22 (0x10f8568)
		TestStackFormat.func1: e, expected, d := Errorf("hi"), callers(), debug.Stack()
	/usr/local/Cellar/go/1.9.4/libexec/src/runtime/asm_amd64.s:509 (0x105438b)
		call32: CALLFN(·call32, 32)
	/usr/local/Cellar/go/1.9.4/libexec/src/runtime/panic.go:491 (0x1029703)
		gopanic: reflectcall(nil, unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
	/Users/john.doe/go/src/github.com/go-errors/errors/error_test.go:247 (0x10f7029)
		c: panic('a')
	/Users/john.doe/go/src/github.com/go-errors/errors/error_test.go:243 (0x10f6fe0)
		b: c()
	/Users/john.doe/go/src/github.com/go-errors/errors/error_test.go:238 (0x10f6f9a)
		a: b(5)
	/Users/john.doe/go/src/github.com/go-errors/errors/error_test.go:44 (0x10f5c78)
		TestStackFormat: a()
	/usr/local/Cellar/go/1.9.4/libexec/src/testing/testing.go:746 (0x10b8150)
		tRunner: fn(t)
	/usr/local/Cellar/go/1.9.4/libexec/src/runtime/asm_amd64.s:2337 (0x1056b61)
		goexit: BYTE	$0x90	// NOP

// debug.Stack() stack trace
goroutine 5 [running]:
	runtime/debug.Stack(0xc4200aa1a0, 0x9, 0x32)
		/usr/local/Cellar/go/1.9.4/libexec/src/runtime/debug/stack.go:24 +0xa7
	github.com/go-errors/errors.TestStackFormat.func1(0xc4200a40f0)
		/Users/john.doe/go/src/github.com/go-errors/errors/error_test.go:22 +0x11f
	panic(0x110fd40, 0x1158b58)
		/usr/local/Cellar/go/1.9.4/libexec/src/runtime/panic.go:491 +0x283
	github.com/go-errors/errors.c()
		/Users/john.doe/go/src/github.com/go-errors/errors/error_test.go:247 +0x39
	github.com/go-errors/errors.b(0x5)
		/Users/john.doe/go/src/github.com/go-errors/errors/error_test.go:243 +0x20
	github.com/go-errors/errors.a(0x8, 0x1149130)
		/Users/john.doe/go/src/github.com/go-errors/errors/error_test.go:238 +0x2a
	github.com/go-errors/errors.TestStackFormat(0xc4200a40f0)
		/Users/john.doe/go/src/github.com/go-errors/errors/error_test.go:44 +0x48
	testing.tRunner(0xc4200a40f0, 0x1149138)
		/usr/local/Cellar/go/1.9.4/libexec/src/testing/testing.go:746 +0xd0
	created by testing.(*T).Run
		/usr/local/Cellar/go/1.9.4/libexec/src/testing/testing.go:789 +0x2de
```