### PR TITLE
optimize SourceLine to not create a new instance of Error from String method

### DIFF
--- a/stackframe.go
+++ b/stackframe.go
@@ -53,7 +53,7 @@ func (frame *StackFrame) Func() *runtime.Func {
 func (frame *StackFrame) String() string {
 	str := fmt.Sprintf("%s:%d (0x%x)\n", frame.File, frame.LineNumber, frame.ProgramCounter)
 
-	source, err := frame.SourceLine()
+	source, err := frame.sourceLine()
 	if err != nil {
 		return str
 	}
@@ -63,13 +63,21 @@ func (frame *StackFrame) String() string {
 
 // SourceLine gets the line of code (from File and Line) of the original source if possible.
 func (frame *StackFrame) SourceLine() (string, error) {
+	source, err := frame.sourceLine()
+	if err != nil {
+		return source, New(err)
+	}
+	return source, err
+}
+
+func (frame *StackFrame) sourceLine() (string, error) {
 	if frame.LineNumber <= 0 {
 		return "???", nil
 	}
 
 	file, err := os.Open(frame.File)
 	if err != nil {
-		return "", New(err)
+		return "", err
 	}
 	defer file.Close()
 
@@ -82,7 +90,7 @@ func (frame *StackFrame) SourceLine() (string, error) {
 		currentLine++
 	}
 	if err := scanner.Err(); err != nil {
-		return "", New(err)
+		return "", err
 	}
 
 	return "???", nil


### PR DESCRIPTION
We noticed that ErrorStack() takes a considerable amount of cpu while computing the stack and the time is spent in SourceLine() method returning a New(err). This error is completely ignored in the String() method. The optimization is to give the builtin error instead of Error from an internal method which can be used by the String() method. To keep the backward compatibility, SourceLine() is modified to invoke the internal method sourceLine() and returning an Error.